### PR TITLE
Fix event listener leak and ghost consumer on reconnection

### DIFF
--- a/lib/base_listener.ts
+++ b/lib/base_listener.ts
@@ -67,8 +67,10 @@ export abstract class BaseListener extends EventEmitter {
         Logger.debug(`${this.constructor.name}: connection lost, clearing channel state`);
         // Try to cancel consumer before clearing channel (in case connection is still valid)
         if (this.consumerTag && this.channel) {
-            this.connection.cancel(this.channel, this.consumerTag).catch(() => {
-                // Ignore - channel likely already closed
+            this.connection.cancel(this.channel, this.consumerTag).catch((error) => {
+                Logger.debug(
+                    `${this.constructor.name}: failed to cancel consumer '${this.consumerTag}' on disconnect (channel may already be closed): ${error instanceof Error ? error.message : String(error)}`
+                );
             });
         }
         this.channel = undefined;

--- a/lib/message_dispatcher.ts
+++ b/lib/message_dispatcher.ts
@@ -124,6 +124,8 @@ export default class MessageDispatcher implements IMessageDispatcher {
     async close(): Promise<void> {
         this.connection.removeListener('disconnected', this._boundOnDisconnected);
         this.connection.removeListener('reconnected', this._boundOnReconnected);
+        delete (this as any)._boundOnDisconnected;
+        delete (this as any)._boundOnReconnected;
         await this.callbackListener.close();
     }
 }

--- a/lib/message_dispatcher.ts
+++ b/lib/message_dispatcher.ts
@@ -31,6 +31,8 @@ export default class MessageDispatcher implements IMessageDispatcher {
 
     private _isInitialized: boolean = false;
     public get isInitialized() { return this._isInitialized; }
+    private _boundOnReconnected: () => void;
+    private _boundOnDisconnected: () => void;
 
     constructor(connection: IConnection) {
         this.connection = connection;
@@ -38,9 +40,11 @@ export default class MessageDispatcher implements IMessageDispatcher {
         this.callbacks = new Map<string, CallbackEntry>();
         this.callbackListener = new CallbackListener(this.connection);
 
-        // Listen for connection events
-        this.connection.on('disconnected', this._onDisconnected.bind(this));
-        this.connection.on('reconnected', this._onReconnected.bind(this));
+        // Listen for connection events (store bound refs for proper cleanup)
+        this._boundOnReconnected = this._onReconnected.bind(this);
+        this._boundOnDisconnected = this._onDisconnected.bind(this);
+        this.connection.on('disconnected', this._boundOnDisconnected);
+        this.connection.on('reconnected', this._boundOnReconnected);
     }
 
     /**
@@ -115,5 +119,11 @@ export default class MessageDispatcher implements IMessageDispatcher {
         return new Promise<Buffer>((resolve: any, reject: any) => {
             this.callbacks.set(id, { resolve, reject } );
         });
+    }
+
+    async close(): Promise<void> {
+        this.connection.removeListener('disconnected', this._boundOnDisconnected);
+        this.connection.removeListener('reconnected', this._boundOnReconnected);
+        await this.callbackListener.close();
     }
 }


### PR DESCRIPTION
## Summary
- Fix memory leak where event listeners accumulated on each reconnection cycle
- Fix ghost consumer issue where old consumers continued receiving messages after reconnection

## Problem 1: Event Listener Leak
The `.bind()` method creates a new function object each time it's called. When registering listeners:
```typescript
this.connection.on('reconnected', this._onReconnected.bind(this));
```
And trying to remove them:
```typescript
this.connection.removeListener('reconnected', this._onReconnected.bind(this));
```
The removal fails because the two `.bind()` calls return different function objects.

**Solution**: Store bound function references as instance properties and reuse them.

## Problem 2: Ghost Consumer
When reconnection occurs, old consumers remained active on RabbitMQ, causing messages to be distributed between old and new consumers (round-robin). This led to:
- Messages processed by stale handler contexts
- Potential data loss if old handlers have invalid DB connections

**Solution**: Cancel existing consumer in `_onDisconnected()` before clearing the channel reference.

## Changes
- `base_listener.ts`: Store bound refs, cancel consumer on disconnect
- `message_dispatcher.ts`: Store bound refs, add `close()` method
- `event_dispatcher.ts`: Store bound refs, add `close()` method

## Test plan
- [x] Build passes (`npm run build`)
- [x] All unit tests pass (`npm test`)
- [x] Ghost consumer reproduction test passes (no ghosts detected after fix)
- [x] Event listener counts remain stable after multiple reconnection cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)